### PR TITLE
翻訳APIのエラー修正

### DIFF
--- a/SHYAK/PHP/Choose your language.php
+++ b/SHYAK/PHP/Choose your language.php
@@ -20,9 +20,9 @@ $translatedText = $translator->translate($originalText);
 echo "<h1>$translatedText</h1>";
 
 // ボタンのテキストも翻訳
-//$yesText = $translator->translate("はい");
+$yesText = $translator->translate("はい");
 $noText = $translator->translate("いいえ");
-echo '<input type="submit" value='$yesText = $translator->translate("はい")'">"';
+echo "<input type='submit' value='$yesText'>";
 echo "<a href='Chooseyourlanguage.php'>$noText</a>";
 
 echo '</div>';

--- a/SHYAK/PHP/api.php
+++ b/SHYAK/PHP/api.php
@@ -1,7 +1,7 @@
 <?php
 
 class Translator {
-    public function translate($text): void {
+    public function translate($text): string {//返り値をvoidからstringに変更
         // cURLの初期化
         $ch = curl_init();
 


### PR DESCRIPTION
一回エラー解消したのでお試し！
Choose your language.phpのシングルクォートとダブルクォートの位置修正、翻訳ファンクションの返り値をvoidからstringに変更しました。