### PR TITLE
翻訳するためのセッション指定

### DIFF
--- a/SHYAK/PHP/Chooseyourlanguage-output.php
+++ b/SHYAK/PHP/Chooseyourlanguage-output.php
@@ -1,0 +1,27 @@
+<?php
+session_start();
+require 'connect.php';
+
+try{
+    if(isset($_SESSION['User']['id']) && isset($_SESSION['User']['username'])){
+        $pdo = new PDO($connect, USER, PASS);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $sql = $pdo->prepare('update Users set country_id = ? where user_id = ? and user_name = ?');
+        $sql->execute([$_POST['language'],$_SESSION['User']['id'],$_SESSION['User']['username']]);
+        $_SESSION['User']['lang'] = $_POST['language'];
+        header('Location: ./top.php');
+        exit();
+    }else{
+        // セッション情報ない(未サインイン)のに飛ばされてきたとき
+        echo '<script>alert("Please sign up");</script>';
+        header('Location: ./signup-input.php');
+        exit();
+    }
+} catch (PDOException $e) {
+    // エラーハンドリング
+    echo '<script>alert("データベースエラー")</script>' . htmlspecialchars($e->getMessage());
+    header('Location: ./signup-input.php');
+    exit();
+}
+
+?>

--- a/SHYAK/PHP/api.php
+++ b/SHYAK/PHP/api.php
@@ -1,5 +1,5 @@
 <?php
-
+session_start();
 class Translator {
     public function translate($text): string {//返り値をvoidからstringに変更
         // cURLの初期化
@@ -16,7 +16,7 @@ class Translator {
 
         // URLと翻訳言語の指定
         $from = 'ja';
-        $to = 'en';
+        $to = $_SESSION['User']['lang'];
         $url = "https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&from=".$from."&to=".$to;
         curl_setopt($ch, CURLOPT_URL, $url);
 

--- a/SHYAK/PHP/signup-output.php
+++ b/SHYAK/PHP/signup-output.php
@@ -50,8 +50,8 @@ try {
                 'id' => $id,
                 'username' => $_POST['username']
             ];
-            // 登録が成功した場合、Top.php にリダイレクト
-            header('Location: ./top.php');
+            // 登録が成功した場合、Chooseyourlangage.php にリダイレクト
+            header('Location: ./Chooseyourlanguage.php');
             exit();
         }
     } else {


### PR DESCRIPTION
セッションに保存された言語情報をもとに翻訳を実行するように修正しています。
また、新規登録に成功した場合は言語選択のページへ遷移し、言語情報を指定させるように変更しました。